### PR TITLE
do not add prefix if it already exists

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 type jobPayload struct {
@@ -41,7 +42,11 @@ func jobs(r *http.Request) error {
 			return err
 		}
 
-		b.Job["ID"] = fmt.Sprintf("%v_%v", *jobPrefix, b.Job["ID"])
+		jID := b.Job["ID"].(string)
+		if !strings.HasPrefix(jID, *jobPrefix) {
+			b.Job["ID"] = fmt.Sprintf("%v_%v", *jobPrefix, b.Job["ID"])
+		}
+
 		b.Job["Name"] = b.Job["ID"]
 		if err := newBody(r, &b); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func modifyRequest(r *http.Request) error {
 // Main Engine function.
 func main() {
 
-	// Setup and Parse Kinngpin.
+	// Setup and Parse Kingpin.
 	kingpin.Version(Version)
 	kingpin.Parse()
 


### PR DESCRIPTION
Problem: when hashi ui calls the api for a job, it calls it with prefixed job name. So proxy add one more prefix to it and it keeps ok adding for each api call for that job.

Solution: Add prefix to job name only when its missing.